### PR TITLE
Download Xyce from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,15 @@ RUN \
 
 FROM trillinos_build as xyce
 
-COPY Xyce-7.1 /opt/Xyce/Xyce-7.1
+RUN \
+    mkdir -p /opt/Xyce && \
+    cd /opt/Xyce && \
+    git clone https://github.com/Xyce/Xyce.git && \
+    cd Xyce && \
+    git checkout Release-7.2.0
 
 RUN \
-    cd /opt/Xyce/Xyce-7.1 && \
+    cd /opt/Xyce/Xyce && \
     ./bootstrap && \
     mkdir build && \
     cd build && \


### PR DESCRIPTION
The current approach suggest filling out a form to download Xyce, while it's also just on git. So I've updated the Dockerfile to download it from there, and also updated to the latest version.